### PR TITLE
Added willChangeCenteredIndexPath method to InfiniteCollectionViewDelegate protocol

### DIFF
--- a/InfiniteLayout/Classes/InfiniteCollectionView.swift
+++ b/InfiniteLayout/Classes/InfiniteCollectionView.swift
@@ -9,9 +9,7 @@ import UIKit
 
 @objc public protocol InfiniteCollectionViewDelegate {
 
-    @objc optional func infiniteCollectionView(_ infiniteCollectionView: InfiniteCollectionView, willChangeCenteredIndexPath centeredIndexPath: IndexPath?)
-    
-    @objc optional func infiniteCollectionView(_ infiniteCollectionView: InfiniteCollectionView, didChangeCenteredIndexPath centeredIndexPath: IndexPath?)
+    @objc optional func infiniteCollectionView(_ infiniteCollectionView: InfiniteCollectionView, didChangeCenteredIndexPath from: IndexPath?, to: IndexPath?)
 }
 
 open class InfiniteCollectionView: UICollectionView {
@@ -172,9 +170,9 @@ extension InfiniteCollectionView: UICollectionViewDelegate {
         
         let preferredVisibleIndexPath = infiniteLayout.preferredVisibleLayoutAttributes()?.indexPath
         if self.centeredIndexPath != preferredVisibleIndexPath {
-            self.infiniteDelegate?.infiniteCollectionView?(self, willChangeCenteredIndexPath: self.centeredIndexPath)
+            let previousCeneteredIndexPath = self.centeredIndexPath
             self.centeredIndexPath = preferredVisibleIndexPath
-            self.infiniteDelegate?.infiniteCollectionView?(self, didChangeCenteredIndexPath: self.centeredIndexPath)
+            self.infiniteDelegate?.infiniteCollectionView?(self, didChangeCenteredIndexPath: previousCeneteredIndexPath, to: self.centeredIndexPath)
         }
     }
     

--- a/InfiniteLayout/Classes/InfiniteCollectionView.swift
+++ b/InfiniteLayout/Classes/InfiniteCollectionView.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 @objc public protocol InfiniteCollectionViewDelegate {
+
+    @objc optional func infiniteCollectionView(_ infiniteCollectionView: InfiniteCollectionView, willChangeCenteredIndexPath centeredIndexPath: IndexPath?)
     
     @objc optional func infiniteCollectionView(_ infiniteCollectionView: InfiniteCollectionView, didChangeCenteredIndexPath centeredIndexPath: IndexPath?)
 }
@@ -170,8 +172,9 @@ extension InfiniteCollectionView: UICollectionViewDelegate {
         
         let preferredVisibleIndexPath = infiniteLayout.preferredVisibleLayoutAttributes()?.indexPath
         if self.centeredIndexPath != preferredVisibleIndexPath {
+            self.infiniteDelegate?.infiniteCollectionView?(self, willChangeCenteredIndexPath: self.centeredIndexPath)
             self.centeredIndexPath = preferredVisibleIndexPath
-            self.infiniteDelegate?.infiniteCollectionView?(self, didChangeCenteredIndexPath: preferredVisibleIndexPath)
+            self.infiniteDelegate?.infiniteCollectionView?(self, didChangeCenteredIndexPath: self.centeredIndexPath)
         }
     }
     

--- a/InfiniteLayout/Classes/InfiniteCollectionView.swift
+++ b/InfiniteLayout/Classes/InfiniteCollectionView.swift
@@ -170,9 +170,9 @@ extension InfiniteCollectionView: UICollectionViewDelegate {
         
         let preferredVisibleIndexPath = infiniteLayout.preferredVisibleLayoutAttributes()?.indexPath
         if self.centeredIndexPath != preferredVisibleIndexPath {
-            let previousCeneteredIndexPath = self.centeredIndexPath
+            let previousCenteredIndexPath = self.centeredIndexPath
             self.centeredIndexPath = preferredVisibleIndexPath
-            self.infiniteDelegate?.infiniteCollectionView?(self, didChangeCenteredIndexPath: previousCeneteredIndexPath, to: self.centeredIndexPath)
+            self.infiniteDelegate?.infiniteCollectionView?(self, didChangeCenteredIndexPath: previousCenteredIndexPath, to: self.centeredIndexPath)
         }
     }
     

--- a/InfiniteLayout/Rx/InfiniteCollectionView+Rx.swift
+++ b/InfiniteLayout/Rx/InfiniteCollectionView+Rx.swift
@@ -38,7 +38,7 @@ extension Reactive where Base: InfiniteCollectionView {
     }
     
     public var itemCentered: ControlEvent<IndexPath?> {
-        let source = infiniteDelegate.sentMessage(#selector(InfiniteCollectionViewDelegate.infiniteCollectionView(_:didChangeCenteredIndexPath:)))
+        let source = infiniteDelegate.sentMessage(#selector(InfiniteCollectionViewDelegate.infiniteCollectionView(_:didChangeCenteredIndexPath:to:)))
             .map { $0.last as? IndexPath }
         return ControlEvent(events: source)
     }


### PR DESCRIPTION
# Overview

This change adds the ability to be notified when the `centeredIndexPath` is about to be updated. This change not only balances the calls to match other methods in UIKit, but is useful when something has been applied on the `didChangeCenteredIndexPath` method and we need to know when to revert it e.g a highlight has been added to the cell in the centre, but that highlight needs to be removed when the use scrolls to the next cell.