### PR TITLE
Update Package.swift manifest to define RxInfiniteLayout product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,27 +4,34 @@
 import PackageDescription
 
 let package = Package(
-  name: "InfiniteLayout",
-  platforms: [.iOS(.v8), .tvOS(.v9)],
-  products: [
-    // Products define the executables and libraries produced by a package, and make them visible to other packages.
-    .library(
-      name: "InfiniteLayout",
-      targets: ["InfiniteLayout"]),
-  ],
-  dependencies: [
-    // Dependencies declare other packages that this package depends on.
-    // .package(url: /* package url */, from: "1.0.0"),
-  ],
-  targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-    .target(
-      name: "CocoaProxy",
-      dependencies: [],
-      publicHeadersPath: "./"),
-    .target(
-      name: "InfiniteLayout",
-      dependencies: ["CocoaProxy"])
-  ]
+    name: "InfiniteLayout",
+    platforms: [.iOS(.v8), .tvOS(.v9)],
+    products: [
+        .library(
+            name: "InfiniteLayout",
+            targets: ["InfiniteLayout"]),
+        .library(
+            name: "RxInfiniteLayout",
+            targets: ["RxInfiniteLayout"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
+        .package(url: "https://github.com/RxSwiftCommunity/RxDataSources.git", .upToNextMajor(from: "4.0.0")),
+    ],
+    targets: [
+        .target(
+            name: "CocoaProxy",
+            dependencies: [],
+            publicHeadersPath: "./"
+        ),
+        .target(
+            name: "InfiniteLayout",
+            dependencies: ["CocoaProxy"]
+        ),
+        .target(
+            name: "RxInfiniteLayout",
+            dependencies: ["InfiniteLayout", "RxSwift", "RxCocoa", "RxDataSources"],
+            path: "Sources/Rx"
+        ),
+    ]
 )

--- a/Sources/InfiniteLayout/InfiniteCollectionView.swift
+++ b/Sources/InfiniteLayout/InfiniteCollectionView.swift
@@ -22,7 +22,7 @@ open class InfiniteCollectionView: UICollectionView {
     open private(set) var centeredIndexPath: IndexPath?
     open var preferredCenteredIndexPath: IndexPath? = IndexPath(item: 0, section: 0)
     
-    var forwardDelegate: Bool { return true }
+    open var forwardDelegate: Bool { return true }
     var _contentSize: CGSize?
     
     override open weak var delegate: UICollectionViewDelegate? {

--- a/Sources/InfiniteLayout/InfiniteDataSource.swift
+++ b/Sources/InfiniteLayout/InfiniteDataSource.swift
@@ -7,17 +7,17 @@
 
 import UIKit
 
-class InfiniteDataSources {
+open class InfiniteDataSources {
     
-    static func section(from infiniteSection: Int, numberOfSections: Int) -> Int {
+    public static func section(from infiniteSection: Int, numberOfSections: Int) -> Int {
         return infiniteSection % numberOfSections
     }
     
-    static func indexPath(from infiniteIndexPath: IndexPath, numberOfSections: Int, numberOfItems: Int) -> IndexPath {
+    public static func indexPath(from infiniteIndexPath: IndexPath, numberOfSections: Int, numberOfItems: Int) -> IndexPath {
         return IndexPath(item: infiniteIndexPath.item % numberOfItems, section: self.section(from: infiniteIndexPath.section, numberOfSections: numberOfSections))
     }
     
-    static func multiplier(estimatedItemSize: CGSize, enabled: Bool) -> Int {
+    public static func multiplier(estimatedItemSize: CGSize, enabled: Bool) -> Int {
         guard enabled else {
             return 1
         }
@@ -26,11 +26,11 @@ class InfiniteDataSources {
         return Int(count)
     }
     
-    static func numberOfSections(numberOfSections: Int, multiplier: Int) -> Int {
+    public static func numberOfSections(numberOfSections: Int, multiplier: Int) -> Int {
         return numberOfSections > 1 ? numberOfSections * multiplier : numberOfSections
     }
     
-    static func numberOfItemsInSection(numberOfItemsInSection: Int, numberOfSections: Int, multiplier: Int) -> Int {
+    public static func numberOfItemsInSection(numberOfItemsInSection: Int, numberOfSections: Int, multiplier: Int) -> Int {
         return numberOfSections > 1 ? numberOfItemsInSection : numberOfItemsInSection * multiplier
     }
 }

--- a/Sources/Rx/InfiniteCollectionView+Rx.swift
+++ b/Sources/Rx/InfiniteCollectionView+Rx.swift
@@ -5,6 +5,10 @@
 //  Created by Arnaud Dorgans on 03/01/2018.
 //
 
+#if canImport(InfiniteLayout)
+import InfiniteLayout
+#endif
+
 import UIKit
 import RxSwift
 import RxCocoa

--- a/Sources/Rx/RxInfiniteCollectionView.swift
+++ b/Sources/Rx/RxInfiniteCollectionView.swift
@@ -5,6 +5,10 @@
 //  Created by Arnaud Dorgans on 03/01/2018.
 //
 
+#if canImport(InfiniteLayout)
+import InfiniteLayout
+#endif
+
 import UIKit
 import RxSwift
 import RxCocoa
@@ -13,7 +17,7 @@ open class RxInfiniteCollectionView: InfiniteCollectionView {
     
     let disposeBag = DisposeBag()
 
-    override var forwardDelegate: Bool {
+    override open var forwardDelegate: Bool {
         return false
     }
     

--- a/Sources/Rx/RxInfiniteCollectionViewDataSource.swift
+++ b/Sources/Rx/RxInfiniteCollectionViewDataSource.swift
@@ -5,6 +5,10 @@
 //  Created by Arnaud Dorgans on 03/01/2018.
 //
 
+#if canImport(InfiniteLayout)
+import InfiniteLayout
+#endif
+
 import UIKit
 import RxDataSources
 


### PR DESCRIPTION
Update Package.swift manifest to define `RxInfiniteLayout` product and target, allowing RxSwift-related classes and extensions to be imported via Swift Package Manager.

This continues to allow importing `InfiniteLayout` via Swift Package Manager without an `RxSwift` dependency, and optionally allows Rx support to be included by depending on the additional `RxInfiniteLayout` product, which depends on `RxSwift`, `RxCocoa` and `RxDataSource`.

Because the Rx-related classes are in a separate library module, they must import the `InfiniteLayout` module. This also required more permissive (open) access to `InfiniteCollectionView` and `InfiniteDataSource`. 

Also, because the `InfiniteLayout` package might not exist when importing this library via CocoaPods (or other dependency managers), I wrapped the import statements in conditional-compilation directives.